### PR TITLE
Fix #01

### DIFF
--- a/dashboard/backends/ros2_channels/channels.py
+++ b/dashboard/backends/ros2_channels/channels.py
@@ -11,6 +11,10 @@ class DataChannel(object):
         self.msg_type = get_message(self.msg_type_str)
         self.graphic = topic_dict.get('graphic_type')
         self.sub_key = self.name + str(self.msg_type) + self.graphic
+    
+    @property
+    def node_name(self):
+        return self.element + self.name.replace('/', '_')
 
 
 class TimeSeriesChannel(DataChannel):

--- a/dashboard/consumers.py
+++ b/dashboard/consumers.py
@@ -1,4 +1,5 @@
 # built-in
+import asyncio
 import json
 
 # django
@@ -16,6 +17,11 @@ class DashboardConsumer(AsyncWebsocketConsumer):
         self.ros2 = ROS2Thread()
         self.subscribers = {}
         self.ros2.start()
+        self.mutex = asyncio.Lock()
+    
+    async def threadsafe_send(self, data):
+        async with self.mutex:
+            await self.send(data)
 
     def add_subscriber(self, topic):
         graphic = topic['graphic_type']
@@ -51,7 +57,6 @@ class DashboardConsumer(AsyncWebsocketConsumer):
                     st = self.add_subscriber(data)
                     # FIXME: provide response to websocket-client
                     print('Subscriber was added with sucess:', st)
-                    return
         # FIXME: provide response to websocket-client
         print('Data format invalid... discarding.')
 


### PR DESCRIPTION
class DataChannel
Adding node_name property on class DataChannel in order to avoid node name collision when providing backend data from different topics for the same graphic element.

classes MapSubscriber and TimeSeriesSubscriber

Using topic.node_name property in replace of topic.element when instatiating ROS2 Nodes in subscribers classes (MapSubscriber and TimeSeriesSubscriber) that will provide data for frontend. Improving async use of the same websocket for different ROS2 subscribers, waiting for lock release. Comment out the logger info message.

class DashboardConsumer

Improving async use, creating a "thread safe" send method, using mutex lock.

piadda.js

Necessary changes in order to allow different topic messages to be show in the same graphic.